### PR TITLE
ci(github): remove automatic reviewers and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owners
+* @thiag0bezerra

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     labels:
       - "dependencies"
       - "automerge"
-    reviewers:
-      - "thiag0bezerra"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -23,5 +21,3 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "actions"
-    reviewers:
-      - "thiag0bezerra"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master  # trocado de main para master
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
- Remove automatic reviewers from dependabot configuration
- Clean up deploy workflow comment
- Add CODEOWNERS file to define code ownership

This improves the CI/CD workflow by relying on CODEOWNERS for review assignments instead of hardcoded reviewers in dependabot.